### PR TITLE
Add linter and cleanup code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,228 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# All files
+[*]
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# Code files
+[*.{cs,csx,razor}]
+indent_size = 4
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# YAML files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Remove unnecessary using directives
+dotnet_diagnostic.IDE0005.severity = warning
+
+# this. preferences
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+dotnet_style_readonly_field = true:warning
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = when_on_single_line:suggestion
+csharp_style_expression_bodied_properties = when_on_single_line:suggestion
+csharp_style_expression_bodied_indexers = when_on_single_line:suggestion
+csharp_style_expression_bodied_accessors = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# Expression-level preferences
+csharp_prefer_braces = true:warning
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Wrapping preferences
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+#### Naming Conventions ####
+
+# Naming rules
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = warning
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = warning
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_field_should_be_begins_with_underscore.severity = warning
+dotnet_naming_rule.private_field_should_be_begins_with_underscore.symbols = private_field
+dotnet_naming_rule.private_field_should_be_begins_with_underscore.style = begins_with_underscore
+
+# Symbol specifications
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+
+dotnet_naming_symbols.private_field.applicable_kinds = field
+dotnet_naming_symbols.private_field.applicable_accessibilities = private, protected, private_protected
+dotnet_naming_symbols.private_field.required_modifiers =
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+
+# Naming styles
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_underscore.required_prefix = _
+dotnet_naming_style.begins_with_underscore.required_suffix =
+dotnet_naming_style.begins_with_underscore.word_separator =
+dotnet_naming_style.begins_with_underscore.capitalization = camel_case
+
+#### StyleCop Analyzer Rules ####
+
+# Documentation Rules (SA1600-SA1651)
+dotnet_diagnostic.SA1600.severity = none  # Elements should be documented
+dotnet_diagnostic.SA1601.severity = none  # Partial elements should be documented
+dotnet_diagnostic.SA1602.severity = none  # Enumeration items should be documented
+dotnet_diagnostic.SA1633.severity = none  # File should have header
+
+# Readability Rules
+dotnet_diagnostic.SA1101.severity = none  # Prefix local calls with this
+
+# Ordering Rules
+dotnet_diagnostic.SA1200.severity = none  # Using directives should be placed correctly
+dotnet_diagnostic.SA1201.severity = warning  # Elements should appear in the correct order
+dotnet_diagnostic.SA1202.severity = warning  # Elements should be ordered by access
+dotnet_diagnostic.SA1204.severity = warning  # Static elements should appear before instance elements
+
+# Naming Rules
+dotnet_diagnostic.SA1309.severity = none  # Field names should not begin with underscore (we use _ for private fields)
+
+# Layout Rules
+dotnet_diagnostic.SA1516.severity = suggestion  # Elements should be separated by blank line
+dotnet_diagnostic.SA1500.severity = warning  # Braces for multi-line statements should not share line
+
+# Maintainability Rules
+dotnet_diagnostic.SA1402.severity = suggestion  # File may only contain a single type
+dotnet_diagnostic.SA1404.severity = warning  # Code analysis suppression should have justification

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -22,8 +22,11 @@ jobs:
       run: dotnet restore
     
     - name: Build
-      run: dotnet build --no-restore
-    
+      run: dotnet build --no-restore -p:TreatWarningsAsErrors=true
+
+    - name: Run tests
+      run: dotnet test --no-build --verbosity normal
+
     - name: Publish
       run: dotnet publish -c Release -o ./publish --self-contained false
     

--- a/EverettEats.UnitTests/EverettEats.UnitTests.csproj
+++ b/EverettEats.UnitTests/EverettEats.UnitTests.csproj
@@ -4,6 +4,11 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn> <!-- Suppress missing XML comment warnings -->
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
@@ -13,6 +18,12 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.70" />
+
+    <!-- Code analysis and linting -->
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EverettEats.csproj" />

--- a/EverettEats.UnitTests/RecipeServiceTests.cs
+++ b/EverettEats.UnitTests/RecipeServiceTests.cs
@@ -1,12 +1,8 @@
 using EverettEats.Models;
 using EverettEats.Services;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Caching.Memory;
 using Moq;
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Xunit;
 
 public class RecipeServiceTests
@@ -19,7 +15,7 @@ public class RecipeServiceTests
         var handler = new Mock<HttpMessageHandler>();
         var httpClient = new HttpClient(handler.Object)
         {
-            BaseAddress = new Uri("http://localhost/")
+            BaseAddress = new Uri("http://localhost/"),
         };
         var cache = new MemoryCache(new MemoryCacheOptions());
         var mockEnv = new Mock<IWebHostEnvironment>();
@@ -29,6 +25,7 @@ public class RecipeServiceTests
         {
             cache.Set("recipes_cache_v1", recipes);
         }
+
         return service;
     }
 
@@ -39,7 +36,7 @@ public class RecipeServiceTests
         var recipes = new List<Recipe>
         {
             new Recipe { Id = 1, Title = "B", DateAdded = DateTime.Now.AddDays(-1) },
-            new Recipe { Id = 2, Title = "A", DateAdded = DateTime.Now }
+            new Recipe { Id = 2, Title = "A", DateAdded = DateTime.Now },
         };
         var service = CreateService(recipes);
 
@@ -57,7 +54,7 @@ public class RecipeServiceTests
     {
         var recipes = new List<Recipe>
         {
-            new Recipe { Id = 1, Title = "Test" }
+            new Recipe { Id = 1, Title = "Test" },
         };
         var service = CreateService(recipes);
         var result = await service.GetRecipeByIdAsync(1);
@@ -70,7 +67,7 @@ public class RecipeServiceTests
     {
         var recipes = new List<Recipe>
         {
-            new Recipe { Id = 1, Title = "Test Slug" }
+            new Recipe { Id = 1, Title = "Test Slug" },
         };
         var service = CreateService(recipes);
         var result = await service.GetRecipeBySlugAsync("test-slug");
@@ -84,7 +81,7 @@ public class RecipeServiceTests
         var recipes = new List<Recipe>
         {
             new Recipe { Id = 1, Title = "Apple Pie" },
-            new Recipe { Id = 2, Title = "Banana Bread" }
+            new Recipe { Id = 2, Title = "Banana Bread" },
         };
         var service = CreateService(recipes);
         var result = await service.SearchRecipesAsync("Apple");
@@ -100,6 +97,7 @@ public class RecipeServiceTests
         {
             recipes.Add(new Recipe { Id = i, Title = $"Recipe {i}", DateAdded = DateTime.Now.AddDays(-i) });
         }
+
         var service = CreateService(recipes);
         var (page, total) = await service.GetPaginatedRecipesAsync(2, 10);
         Assert.Equal(10, page.Count);

--- a/EverettEats.UnitTests/RecipeServiceTests.cs
+++ b/EverettEats.UnitTests/RecipeServiceTests.cs
@@ -10,25 +10,6 @@ public class RecipeServiceTests
     private readonly Mock<HttpClient> _httpClientMock = new();
     private readonly IMemoryCache _memoryCache = new MemoryCache(new MemoryCacheOptions());
 
-    private RecipeService CreateService(List<Recipe>? recipes = null)
-    {
-        var handler = new Mock<HttpMessageHandler>();
-        var httpClient = new HttpClient(handler.Object)
-        {
-            BaseAddress = new Uri("http://localhost/"),
-        };
-        var cache = new MemoryCache(new MemoryCacheOptions());
-        var mockEnv = new Mock<IWebHostEnvironment>();
-        mockEnv.Setup(e => e.WebRootPath).Returns("/tmp");
-        var service = new RecipeService(httpClient, cache, mockEnv.Object);
-        if (recipes != null)
-        {
-            cache.Set("recipes_cache_v1", recipes);
-        }
-
-        return service;
-    }
-
     [Fact]
     public async Task GetAllRecipesAsync_ReturnsRecipesOrderedByDate()
     {
@@ -103,5 +84,24 @@ public class RecipeServiceTests
         Assert.Equal(10, page.Count);
         Assert.Equal(25, total);
         Assert.Equal("Recipe 11", page[0].Title);
+    }
+
+    private RecipeService CreateService(List<Recipe>? recipes = null)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        var httpClient = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri("http://localhost/"),
+        };
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var mockEnv = new Mock<IWebHostEnvironment>();
+        mockEnv.Setup(e => e.WebRootPath).Returns("/tmp");
+        var service = new RecipeService(httpClient, cache, mockEnv.Object);
+        if (recipes != null)
+        {
+            cache.Set("recipes_cache_v1", recipes);
+        }
+
+        return service;
     }
 }

--- a/EverettEats.csproj
+++ b/EverettEats.csproj
@@ -4,11 +4,22 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>EverettEats</RootNamespace>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn> <!-- Suppress missing XML comment warnings -->
   </PropertyGroup>
 
   <ItemGroup>
     <!-- Blazor Server packages -->
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10" />
+
+    <!-- Code analysis and linting -->
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <!-- Only exclude the unit tests directory now -->

--- a/Models/DifficultyLevel.cs
+++ b/Models/DifficultyLevel.cs
@@ -1,9 +1,9 @@
 namespace EverettEats.Models
 {
-	public enum DifficultyLevel
-	{
-		Easy,
-		Medium,
-		Hard
-	}
+    public enum DifficultyLevel
+    {
+        Easy,
+        Medium,
+        Hard,
+    }
 }

--- a/Models/Recipe.cs
+++ b/Models/Recipe.cs
@@ -1,45 +1,43 @@
-
 using System.ComponentModel.DataAnnotations;
-using EverettEats.Models;
 
 namespace EverettEats.Models
 {
-	public class Recipe
-	{
-		public int Id { get; set; }
+    public class Recipe
+    {
+        public int Id { get; set; }
 
-		[Required]
-		public string Title { get; set; } = string.Empty;
+        [Required]
+        public string Title { get; set; } = string.Empty;
 
-		public string Description { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
 
-		public string ImageUrl { get; set; } = string.Empty;
+        public string ImageUrl { get; set; } = string.Empty;
 
-		[Required]
-		public string PrepTime { get; set; } = string.Empty;
+        [Required]
+        public string PrepTime { get; set; } = string.Empty;
 
-		[Required]
-		public string CookTime { get; set; } = string.Empty;
+        [Required]
+        public string CookTime { get; set; } = string.Empty;
 
-		public string TotalTime { get; set; } = string.Empty;
+        public string TotalTime { get; set; } = string.Empty;
 
-		public string Servings { get; set; } = string.Empty;
+        public string Servings { get; set; } = string.Empty;
 
-		public List<string> Ingredients { get; set; } = [];
+        public List<string> Ingredients { get; set; } = [];
 
-		public List<string> Instructions { get; set; } = [];
+        public List<string> Instructions { get; set; } = [];
 
-		public List<string> Tips { get; set; } = [];
+        public List<string> Tips { get; set; } = [];
 
-		public DateTime DateAdded { get; set; } = DateTime.Now;
+        public DateTime DateAdded { get; set; } = DateTime.Now;
 
-		public RecipeCategory Category { get; set; } = RecipeCategory.Desserts;
+        public RecipeCategory Category { get; set; } = RecipeCategory.Desserts;
 
-		public DifficultyLevel Difficulty { get; set; } = DifficultyLevel.Easy;
+        public DifficultyLevel Difficulty { get; set; } = DifficultyLevel.Easy;
 
-		public List<string> Tags { get; set; } = [];
+        public List<string> Tags { get; set; } = [];
 
-		// SEO-friendly URL slug
-		public string Slug { get; set; } = string.Empty;
-	}
+        // SEO-friendly URL slug
+        public string Slug { get; set; } = string.Empty;
+    }
 }

--- a/Models/RecipeCategory.cs
+++ b/Models/RecipeCategory.cs
@@ -1,13 +1,13 @@
 namespace EverettEats.Models
 {
-	public enum RecipeCategory
-	{
-		Desserts,
-		MainDishes,
-		Appetizers,
-		Sides,
-		Beverages,
-		Breakfast,
-		Snacks
-	}
+    public enum RecipeCategory
+    {
+        Desserts,
+        MainDishes,
+        Appetizers,
+        Sides,
+        Beverages,
+        Breakfast,
+        Snacks,
+    }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,4 @@
-using EverettEats;
 using EverettEats.Services;
-using Microsoft.Extensions.Caching.Memory;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/Services/IRecipeService.cs
+++ b/Services/IRecipeService.cs
@@ -1,15 +1,14 @@
-
 using EverettEats.Models;
 
 namespace EverettEats.Services
 {
-	public interface IRecipeService
-	{
-		Task<List<Recipe>> GetAllRecipesAsync();
-		Task<Recipe?> GetRecipeByIdAsync(int id);
-		Task<Recipe?> GetRecipeBySlugAsync(string slug);
-		Task<List<Recipe>> GetRecipesByCategoryAsync(RecipeCategory category);
-		Task<List<Recipe>> SearchRecipesAsync(string searchTerm);
-		Task<(List<Recipe> Recipes, int TotalCount)> GetPaginatedRecipesAsync(int pageNumber, int pageSize, string? searchTerm = null, RecipeCategory? category = null);
-	}
+    public interface IRecipeService
+    {
+        Task<List<Recipe>> GetAllRecipesAsync();
+        Task<Recipe?> GetRecipeByIdAsync(int id);
+        Task<Recipe?> GetRecipeBySlugAsync(string slug);
+        Task<List<Recipe>> GetRecipesByCategoryAsync(RecipeCategory category);
+        Task<List<Recipe>> SearchRecipesAsync(string searchTerm);
+        Task<(List<Recipe> Recipes, int TotalCount)> GetPaginatedRecipesAsync(int pageNumber, int pageSize, string? searchTerm = null, RecipeCategory? category = null);
+    }
 }

--- a/Services/RecipeService.cs
+++ b/Services/RecipeService.cs
@@ -1,137 +1,142 @@
-using EverettEats.Models;
-using System.Net.Http.Json;
 using System.Text.Json;
+using EverettEats.Models;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace EverettEats.Services
 {
-	public class RecipeService : IRecipeService
-	{
-		private readonly HttpClient _httpClient;
-		private readonly IMemoryCache _cache;
-		private readonly IWebHostEnvironment _env;
-		private const string RecipesCacheKey = "recipes_cache_v1";
-		private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(30);
+    public class RecipeService : IRecipeService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly IMemoryCache _cache;
+        private readonly IWebHostEnvironment _env;
+        private const string RecipesCacheKey = "recipes_cache_v1";
+        private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(30);
 
-		public RecipeService(HttpClient httpClient, IMemoryCache cache, IWebHostEnvironment env)
-		{
-			_httpClient = httpClient;
-			_cache = cache;
-			_env = env;
-		}
+        public RecipeService(HttpClient httpClient, IMemoryCache cache, IWebHostEnvironment env)
+        {
+            _httpClient = httpClient;
+            _cache = cache;
+            _env = env;
+        }
 
-		public async Task<List<Recipe>> GetAllRecipesAsync()
-		{
-			var recipes = await GetRecipesFromCacheAsync();
-			return recipes.OrderByDescending(r => r.DateAdded).ToList();
-		}
+        public async Task<List<Recipe>> GetAllRecipesAsync()
+        {
+            var recipes = await GetRecipesFromCacheAsync();
+            return recipes.OrderByDescending(r => r.DateAdded).ToList();
+        }
 
-		public async Task<Recipe?> GetRecipeByIdAsync(int id)
-		{
-			var recipes = await GetRecipesFromCacheAsync();
-			return recipes.FirstOrDefault(r => r.Id == id);
-		}
+        public async Task<Recipe?> GetRecipeByIdAsync(int id)
+        {
+            var recipes = await GetRecipesFromCacheAsync();
+            return recipes.FirstOrDefault(r => r.Id == id);
+        }
 
-		public async Task<Recipe?> GetRecipeBySlugAsync(string slug)
-		{
-			var recipes = await GetRecipesFromCacheAsync();
-			return recipes.FirstOrDefault(r => r.Slug == slug);
-		}
+        public async Task<Recipe?> GetRecipeBySlugAsync(string slug)
+        {
+            var recipes = await GetRecipesFromCacheAsync();
+            return recipes.FirstOrDefault(r => r.Slug == slug);
+        }
 
-		public async Task<List<Recipe>> GetRecipesByCategoryAsync(RecipeCategory category)
-		{
-			var recipes = await GetRecipesFromCacheAsync();
-			return recipes.Where(r => r.Category == category).ToList();
-		}
+        public async Task<List<Recipe>> GetRecipesByCategoryAsync(RecipeCategory category)
+        {
+            var recipes = await GetRecipesFromCacheAsync();
+            return recipes.Where(r => r.Category == category).ToList();
+        }
 
-		public async Task<List<Recipe>> SearchRecipesAsync(string searchTerm)
-		{
-			var recipes = await GetRecipesFromCacheAsync();
-			if (string.IsNullOrWhiteSpace(searchTerm))
-				return recipes.OrderByDescending(r => r.DateAdded).ToList();
+        public async Task<List<Recipe>> SearchRecipesAsync(string searchTerm)
+        {
+            var recipes = await GetRecipesFromCacheAsync();
+            if (string.IsNullOrWhiteSpace(searchTerm))
+            {
+                return recipes.OrderByDescending(r => r.DateAdded).ToList();
+            }
 
-			return recipes.Where(r =>
-				r.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
-				r.Description.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
-				r.Tags.Any(tag => tag.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
-				r.Ingredients.Any(ingredient => ingredient.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
-			).OrderByDescending(r => r.DateAdded).ToList();
-		}
+            return recipes.Where(r =>
+                r.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
+                r.Description.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
+                r.Tags.Any(tag => tag.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
+                r.Ingredients.Any(ingredient => ingredient.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)))
+            .OrderByDescending(r => r.DateAdded).ToList();
+        }
 
-		public async Task<(List<Recipe> Recipes, int TotalCount)> GetPaginatedRecipesAsync(int pageNumber, int pageSize, string? searchTerm = null, RecipeCategory? category = null)
-		{
-			var recipes = await GetRecipesFromCacheAsync();
-			IEnumerable<Recipe> filtered = recipes;
-			if (!string.IsNullOrWhiteSpace(searchTerm))
-			{
-				filtered = filtered.Where(r =>
-					r.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
-					r.Description.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
-					r.Tags.Any(tag => tag.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
-					r.Ingredients.Any(ingredient => ingredient.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
-				);
-			}
-			if (category.HasValue)
-			{
-				filtered = filtered.Where(r => r.Category == category.Value);
-			}
-			var total = filtered.Count();
-			var page = filtered
-				.OrderByDescending(r => r.DateAdded)
-				.Skip((pageNumber - 1) * pageSize)
-				.Take(pageSize)
-				.ToList();
-			return (page, total);
-		}
+        public async Task<(List<Recipe> Recipes, int TotalCount)> GetPaginatedRecipesAsync(int pageNumber, int pageSize, string? searchTerm = null, RecipeCategory? category = null)
+        {
+            var recipes = await GetRecipesFromCacheAsync();
+            IEnumerable<Recipe> filtered = recipes;
+            if (!string.IsNullOrWhiteSpace(searchTerm))
+            {
+                filtered = filtered.Where(r =>
+                    r.Title.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
+                    r.Description.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ||
+                    r.Tags.Any(tag => tag.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)) ||
+                    r.Ingredients.Any(ingredient => ingredient.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)));
+            }
 
-		private async Task<List<Recipe>> GetRecipesFromCacheAsync()
-		{
-			if (!_cache.TryGetValue(RecipesCacheKey, out List<Recipe>? recipes) || recipes == null)
-			{
-				try
-				{
-					// Try loading from file system first (more reliable during prerendering)
-					var filePath = Path.Combine(_env.WebRootPath, "data", "recipes.json");
-					Console.WriteLine($"Loading recipes from file: {filePath}");
+            if (category.HasValue)
+            {
+                filtered = filtered.Where(r => r.Category == category.Value);
+            }
 
-					if (File.Exists(filePath))
-					{
-						var json = await File.ReadAllTextAsync(filePath);
-						var options = new JsonSerializerOptions
-						{
-							PropertyNameCaseInsensitive = true
-						};
-						recipes = JsonSerializer.Deserialize<List<Recipe>>(json, options) ?? new List<Recipe>();
-						Console.WriteLine($"Successfully loaded {recipes.Count} recipes from file system");
-						if (recipes.Count > 0)
-						{
-							Console.WriteLine($"First recipe: Id={recipes[0].Id}, Title={recipes[0].Title}, Slug={recipes[0].Slug}");
-						}
-					}
-					else
-					{
-						Console.WriteLine($"File not found, trying HTTP: {_httpClient.BaseAddress}data/recipes.json");
-						var options = new JsonSerializerOptions
-						{
-							PropertyNameCaseInsensitive = true
-						};
-						recipes = await _httpClient.GetFromJsonAsync<List<Recipe>>("data/recipes.json", options) ?? new List<Recipe>();
-						Console.WriteLine($"Successfully loaded {recipes.Count} recipes via HTTP");
-					}
-				}
-				catch (Exception ex)
-				{
-					Console.WriteLine($"Failed to load recipes: {ex.GetType().Name}: {ex.Message}");
-					Console.WriteLine($"Stack trace: {ex.StackTrace}");
-					if (ex.InnerException != null)
-					{
-						Console.WriteLine($"Inner exception: {ex.InnerException.GetType().Name}: {ex.InnerException.Message}");
-					}
-					recipes = new List<Recipe>();
-				}
-				_cache.Set(RecipesCacheKey, recipes, CacheDuration);
-			}
-			return recipes;
-		}
-	}
+            var total = filtered.Count();
+            var page = filtered
+                .OrderByDescending(r => r.DateAdded)
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToList();
+            return (page, total);
+        }
+
+        private async Task<List<Recipe>> GetRecipesFromCacheAsync()
+        {
+            if (!_cache.TryGetValue(RecipesCacheKey, out List<Recipe>? recipes) || recipes == null)
+            {
+                try
+                {
+                    // Try loading from file system first (more reliable during prerendering)
+                    var filePath = Path.Combine(_env.WebRootPath, "data", "recipes.json");
+                    Console.WriteLine($"Loading recipes from file: {filePath}");
+
+                    if (File.Exists(filePath))
+                    {
+                        var json = await File.ReadAllTextAsync(filePath);
+                        var options = new JsonSerializerOptions
+                        {
+                            PropertyNameCaseInsensitive = true,
+                        };
+                        recipes = JsonSerializer.Deserialize<List<Recipe>>(json, options) ?? new List<Recipe>();
+                        Console.WriteLine($"Successfully loaded {recipes.Count} recipes from file system");
+                        if (recipes.Count > 0)
+                        {
+                            Console.WriteLine($"First recipe: Id={recipes[0].Id}, Title={recipes[0].Title}, Slug={recipes[0].Slug}");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"File not found, trying HTTP: {_httpClient.BaseAddress}data/recipes.json");
+                        var options = new JsonSerializerOptions
+                        {
+                            PropertyNameCaseInsensitive = true,
+                        };
+                        recipes = await _httpClient.GetFromJsonAsync<List<Recipe>>("data/recipes.json", options) ?? new List<Recipe>();
+                        Console.WriteLine($"Successfully loaded {recipes.Count} recipes via HTTP");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to load recipes: {ex.GetType().Name}: {ex.Message}");
+                    Console.WriteLine($"Stack trace: {ex.StackTrace}");
+                    if (ex.InnerException != null)
+                    {
+                        Console.WriteLine($"Inner exception: {ex.InnerException.GetType().Name}: {ex.InnerException.Message}");
+                    }
+
+                    recipes = new List<Recipe>();
+                }
+
+                _cache.Set(RecipesCacheKey, recipes, CacheDuration);
+            }
+
+            return recipes;
+        }
+    }
 }

--- a/Services/RecipeService.cs
+++ b/Services/RecipeService.cs
@@ -6,11 +6,11 @@ namespace EverettEats.Services
 {
     public class RecipeService : IRecipeService
     {
+        private const string _recipesCacheKey = "recipes_cache_v1";
+        private static readonly TimeSpan _cacheDuration = TimeSpan.FromMinutes(30);
         private readonly HttpClient _httpClient;
         private readonly IMemoryCache _cache;
         private readonly IWebHostEnvironment _env;
-        private const string RecipesCacheKey = "recipes_cache_v1";
-        private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(30);
 
         public RecipeService(HttpClient httpClient, IMemoryCache cache, IWebHostEnvironment env)
         {
@@ -88,7 +88,7 @@ namespace EverettEats.Services
 
         private async Task<List<Recipe>> GetRecipesFromCacheAsync()
         {
-            if (!_cache.TryGetValue(RecipesCacheKey, out List<Recipe>? recipes) || recipes == null)
+            if (!_cache.TryGetValue(_recipesCacheKey, out List<Recipe>? recipes) || recipes == null)
             {
                 try
                 {
@@ -133,7 +133,7 @@ namespace EverettEats.Services
                     recipes = new List<Recipe>();
                 }
 
-                _cache.Set(RecipesCacheKey, recipes, CacheDuration);
+                _cache.Set(_recipesCacheKey, recipes, _cacheDuration);
             }
 
             return recipes;


### PR DESCRIPTION
This PR adds comprehensive code quality tooling to enforce consistent C# coding standards across the codebase.

 ## Changes

  Linting & Code Analysis:
  - Added StyleCop.Analyzers to both main and test projects
  - Created .editorconfig with C# coding conventions (naming, formatting, organization)
  - Enabled unused using statement detection (IDE0005)
  - Enabled .NET code analyzers with latest rules

  CI/CD Enforcement:
  - Updated GitHub Actions workflow to treat warnings as errors (-p:TreatWarningsAsErrors=true)
  - Added test execution step before deployment
  - Build will now fail on any linting violations

  Code Fixes:
  - Reordered class members to follow StyleCop conventions (constants before fields, public before private)
  - Applied consistent naming conventions (const/static fields now use underscore prefix)

  Impact

  - Local builds show warnings but don't fail
  - CI builds enforce all linting rules and will block merges with violations
  - Run dotnet format EverettEats.sln to auto-fix formatting issues